### PR TITLE
Create Committee Charter

### DIFF
--- a/committee_charter.md
+++ b/committee_charter.md
@@ -1,0 +1,87 @@
+# Committee Charter: Library Carpentry Governance Committee
+Approval date: pending <br />
+Status: active <br />
+
+
+## Description/Problem Statement
+
+The committee is established to provide community leadership for the Library Carpentry lesson program. 
+Committee members represent the interests of the lesson program community, 
+overseeing project strategy and informing the actions of the Core Team and Executive Council as they relate to the lesson program.
+
+
+## Objectives/Purpose
+
+Activities of the committee will fall into three categories:
+
+* Strategy:
+    * Monitoring the health of the lesson program and designing strategies to maintain and improve it
+    * Identifying priorities for growing the community and reach of the lesson program
+    * Working with Core Team and other community members to act on the strategic priorities identified
+* Advocacy:
+    * Representing the lesson program in their local and professional networks
+    * Working with the Executive Council and Core Team to promote the interests of the lesson program within The Carpentries
+* Communication:
+    * Reporting on the activities, objectives, and needs of the lesson program to the Executive Council and Core Team
+    * Engaging the community on topics and projects relevant to the development of the lesson program
+    * Working with the Core Team to maintain up-to-date information about the lesson program on The Carpentries websites
+
+
+## Roles and Responsibilities
+
+- Chair, responsible for:
+    - overall leadership of the committee and advancing its aims and objectives
+    - preparing meeting agendas, sharing agendas with the committee in advance, 
+      setting meeting roles, and approving meeting minutes for publication
+    - serving as the main point of contact for the committee
+    - keeping the committee documentation up to date
+    - producing periodic reports to The Carpentries Executive Council
+- Secretary, responsible for:
+    - scheduling meetings and sharing calendar invitations
+    - providing a location for online meetings
+    - preparing meeting minutes and publishing them following approval
+- Member, responsible for:
+    - notifying Chair of potential agenda items as they arise
+    - reading agenda and other relevant documents sent by Chair prior to meeting
+    - attending and actively participating in regular meetings
+    - participating in asynchronous voting through GitHub as needed.
+    - working with Core Team and community members to implement committee recommendations as needed
+
+
+## Operational Procedures
+
+Processes for recruiting/selecting new members for the committee, onboarding and offboarding of members, 
+and succession planning for officer roles, are detailed in [the Lesson Program Governor handbook][lpgc-handbook].
+
+### Decision making process
+
+**LPGCs please discuss how you want to make decisions, 
+and add details in this section before the charter is submitted to the Executive Council for approval.**
+
+### Meetings
+
+Meetings of the Governance Committee are private to members of the committee.
+To raise something for discussion with the committee, send a message to [the TopicBox list][topicbox].
+
+Minutes of past meetings are available in [the `minutes` directory][minutes] of this repository.
+
+
+## Core Team Liasion
+
+Toby Hodges, Director of Curriculum
+
+
+## Members
+
+### Current Members
+
+- Yared Abera
+- Mary Filsell
+- Ekaterina Grguric (Chair)
+- Elizabeth McAulay (Secretary)
+- Belinda Weaver
+
+
+[lpgc-handbook]: FIXME
+[minutes]: ./minutes/
+[topicbox]: https://carpentries.topicbox.com/groups/swc-governors/

--- a/committee_charter.md
+++ b/committee_charter.md
@@ -84,4 +84,4 @@ Toby Hodges, Director of Curriculum
 
 [lpgc-handbook]: FIXME
 [minutes]: ./minutes/
-[topicbox]: https://carpentries.topicbox.com/groups/swc-governors/
+[topicbox]: https://carpentries.topicbox.com/groups/lc-governors/

--- a/committee_charter.md
+++ b/committee_charter.md
@@ -77,7 +77,7 @@ Toby Hodges, Director of Curriculum
 
 - Yared Abera
 - Mary Filsell
-- Ekaterina Grguric (Chair)
+- Ekatarina Grguric (Chair)
 - Elizabeth McAulay (Secretary)
 - Belinda Weaver
 


### PR DESCRIPTION
This pull request will add a draft of the Library Carpentry Governance Committee Charter: [a document required by The Carpentries Committee Policy](https://docs.carpentries.org/topic_folders/governance/committee-policy.html#committee-operations).

I have filled in as much as I can, but I would like you all to check through it, and add in/edit any content as needed. You can edit the content as you like (while keeping the overall structure), but here are a couple of places that I think most need your attention:

1. The _Decision making process_ section needs to be filled in. Please discuss within your committee how you would like to make decisions ([consensus][1], [lazy consensus][2], [majority vote][3], using [Martha's Rules][4], etc) and edit the file accordingly.
2. Check that your names and other information are listed correctly.

The link to the Lesson Program Governor Handbook does not work yet, but that document is very close to being ready for publication - I will come back and add in the correct URL as soon as possible.

(One more note: I had been under the impression that the charter document needed to be approved by the Executive Council but, after closer inspection of the policy, I no longer think that is true. Nevertheless, it is a resource that could be helpful for community members, and newcomers to the committee, to easily understand the purpose of the group.)

[1]: https://medlabboulder.gitlab.io/democraticmediums/mediums/consensus/
[2]: https://medlabboulder.gitlab.io/democraticmediums/mediums/lazy_consensus/
[3]: https://medlabboulder.gitlab.io/democraticmediums/mediums/majority_voting/
[4]: https://third-bit.com/files/2020/08/marthas/
