### PR TITLE
Create 2026-01-minutes.md

### DIFF
--- a/minutes/2026-01-minutes.md
+++ b/minutes/2026-01-minutes.md
@@ -1,0 +1,57 @@
+# Library Carpentry Governance Committee (LCGC)  
+### Meeting minutes: 2026-01-21 UTC 16:00
+
+Attending: Cody Hennesy, Jennifer Stubbs, Nicky Garland, Tim Dennis, Eka Grguric, Lebogang Seleka‑Gopolang, Toby Hodges
+
+## Agenda & notes
+
+### Encouraging more Library Carpentry workshops
+- The official LC workshop count for 2025 was low but many LC sessions are only offered locally or adapted forks and therefore go unreported as Carpentries events. The workshop form and website may be barriers to reporting.
+- We discussed how to improve reporting options (allow URLs for forks), outreach to library conferences, offering more online LC workshops, and providing guidance on minimal requirements to count as a Carpentries workshop. 
+
+Action items:
+
+- Toby will discuss reporting/form/website feedback with Carpentries team.
+- Tim can do a GitHub LC org tour at next meeting, including how to update LC site.
+- LCGC will identify conference/outreach opportunities and pilot more online LC workshops (members to surface local leads).
+
+### CaSDaR (RDM) grant update
+- Grant submitted to develop UK‑focused RDM curriculum; PIs at University of York. Decision expected end of February. If funded, includes limited travel/time for LCGC involvement; Nicky listed at 10% on grant for nine months.
+
+Action items:
+
+- Nicky & Toby will report back on funding decision and any opportunities for LCGC involvement.
+
+### Pathways (curriculum sequencing)
+- Proposal to produce a lightweight set of recommended pathways (e.g., 2‑hr, half‑day, full‑day options; list prerequisites and intended audience).
+- U York grant and UBC RDM work could contribute content to RDM paths.
+
+Action items:
+
+- Cody will prepare initial pathways draft and circulate to LCGC. 
+
+### Lesson review & maintenance
+- Plan for LCGC to do an annual review of lessons for currency and retirement. LCGC role: support maintainers (GitHub coaching), offer sprints, and help triage outdated lessons.
+- New maintainer lead (Jose Muriel) should be invited to LCGC to coordinate outreach.
+
+Action items:
+
+- Cody will invite Maintainer lead, Jose Muriel to engage with LCGC.
+- Group will plan to add lesson review to annual meeting plans; volunteers to assist maintainers and run sprints.
+
+### Old business / repo transfers
+- Wikidata lesson moved to alpha.
+- GLAM Machine Learning repo transfer needs discussion with authors and process clarification.
+- LC MarcEdit awaiting one final review (scheduled for early Feb).
+- Open Science pilot call: Tim to invite more LCGC participation.
+
+Action items:
+
+- Toby will coordinate with maintainers and Technology team on GLAM ML and other repo transfers.
+- Tim will post call for Open Science lesson pilots and invite contributors to LCGC as needed.
+
+
+## Next steps / next meeting
+- Tim to run GitHub org tour and demonstrate editing LC site.
+- Cody to circulate pathways draft ahead of next meeting.
+


### PR DESCRIPTION
Adding minutes from Jan 2026. No longer using folder structure by year in minutes/ and using format YYYY-MM-minutes.md instead, which will sort by year and month. 