### PR TITLE
Create 2026-05-minutes.md

### DIFF
--- a/minutes/2026/2026-05-minutes.md
+++ b/minutes/2026/2026-05-minutes.md
@@ -1,0 +1,49 @@
+# Library Carpentry Governance Committee (LCGC)  
+
+**Meeting minutes: 2026-05-20 UTC 16:00**  
+**Attending:** Jennifer Stubbs, Nicky Garland, Nathaniel Porter, Tim Dennis, Eka Grguric  
+**Apologies:** Cody Hennesy  
+
+## Updates
+* **Lessons:** Cody sent notes that the Wikidata lesson updates are moving fast and will be re-added to the LC Lessons page soon. The Qualitative Research lessons will follow once a few PRs fixing Instructor Notes links merge.
+* **Blog post:** We're going to draft a Carpentries blog post about these recent lesson updates, using the [DMP101 announcement](https://carpentries.org/blog/2024/06/library-carpentry-dmp-lesson-approved/) as a template.
+  * *Action:* Nathaniel will start drafting the blog post.
+  * *Action:* Cody will add Wikidata and Qualitative Research to the LC Lessons page after the PRs merge.
+
+## UC Library Carpentry workshops
+* The recent UC workshop series had a great turnout—over 100 registrants per session, and people actually kept showing up across the multiple sessions. Attendees came from UCLA, several iSchools, and a wider geographic spread than we expected.
+* This brought up regional coordination. Scott Peterson is doing similar work in the Northeast, which could serve as a good model for us. Pooling instructors across institutions helps areas without a strong local iSchool presence. We need better visibility into who is organizing locally and should look into partnering with regional networks to get the word out.
+  * *Action:* Tim to look up contacts from the historical Maintainers Workshop regional talks.
+  * *Action:* Jennifer S. to contact Justin Wadland and others in the Midwest.
+
+## Open Science lessons
+* The UCLA IMLS Open Science pilot cohort posted their [first results blog](https://ucla-imls-open-sci.info/blog/2026-05-19-pilots-first-results/). 
+* Toby updated the [GitHub preview instructions](https://carpentries.github.io/github-skills/dev-ide.html) for lesson authors.
+* We talked about how to better support authors moving lessons from alpha to beta and stable. New authors specifically need help with GitHub PR workflows. We also need to rewrite some instructor notes so they aren't strictly geared toward US librarians and include better framing for humanities audiences.
+  * *Action:* Jennifer S. and Tim to schedule mentoring sessions for authors on GitHub/PR workflows.
+  * *Action:* Jennifer S. to add guidance to instructor notes for broader/humanities audiences.
+  * *Action:* Everyone to think about reusable onboarding docs for new authors.
+
+## LC Pathways / UX testing
+* Eka noted that UX testing prep is a little behind schedule but moving. The script is mostly done and reviewed, so scheduling will start soon. We'll need to look outside our usual listservs to recruit testers.
+* Jennifer S. is putting together an ACRL panel proposal on how creating and teaching LC lessons counts as professional development.
+* We debated whether beta lessons (like Wikidata and AI for GLAM) are ready to feature publicly. We agreed that if they are teachable, we should highlight them.
+  * *Action:* Eka to start scheduling UX testers.
+  * *Action:* Everyone to help recruit testers outside standard channels.
+  * *Action:* Jennifer S. to continue working on the ACRL panel proposal.
+
+## DMP101 report out
+* Only one person showed up to the last DMP101 session, but it was still a good chance to build a connection. There's interest from the Midwest regional meeting, so people do still want librarian-focused sessions.
+* We got some feedback during the session that needs to be logged.
+  * *Action:* Log the DMP101 session feedback in GitHub issues.
+
+## Maintainers & Governance
+* We welcomed the new maintainers, but we still need more. We also need a better way for maintainers and the LCGC to communicate.
+* We need to do a better job clearly explaining what the maintainer role is, and making sure the work is recognized as a scholarly contribution. We pitched a few ideas, including asynchronous contribution sprints and making our meetings and calendars more public.
+  * *Action:* Jennifer S. to organize a Q3 "Q&A with LCGC" session.
+  * *Action:* Tim to talk to Jose Niño Muriel about maintainer engagement.
+
+---
+**Next meeting:** June 17, 2026, 16:00 UTC  
+**Topic:** Jupyter Lite as an alternate Python setup  
+**Notes/Agenda:** [LCGC Etherpad](https://pad.carpentries.org/lc-governance-2026)


### PR DESCRIPTION
Updates Library Carpentry Governance Committee (LCGC) meeting minutes for May 20, 2026. Key highlights include lesson updates (Wikidata/Qualitative Research), reflections on the UC workshop series, progress on Open Science pilot mentoring, and planning for Q3 maintainer outreach.